### PR TITLE
added filtered job executions by job name LIKE DAO method and implemented search query at API level.

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JdbcSearchableJobExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JdbcSearchableJobExecutionDao.java
@@ -211,13 +211,13 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 	public List<JobExecutionWithStepCount> getFilteredJobExecutionsWithStepCount(String q, int start, int count) {
 		if (start <= 0) {
 			return getJdbcTemplate().query(byJobNameWithStepCountPagingQueryProvider.generateFirstPageQuery(count),
-					new JobExecutionStepCountRowMapper(), "%" + q + "q");
+					new JobExecutionStepCountRowMapper(), "%" + q + "%");
 		}
 		try {
 			Long startAfterValue = getJdbcTemplate().queryForObject(
 					executionsWithStepCountPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class);
 			return getJdbcTemplate().query(byJobNameWithStepCountPagingQueryProvider.generateRemainingPagesQuery(count),
-					new JobExecutionStepCountRowMapper(), "%" + q + "q", startAfterValue);
+					new JobExecutionStepCountRowMapper(), "%" + q + "%", startAfterValue);
 		}
 		catch (IncorrectResultSizeDataAccessException e) {
 			return Collections.emptyList();

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JdbcSearchableJobExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JdbcSearchableJobExecutionDao.java
@@ -208,16 +208,16 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 	}
 
 	@Override
-	public List<JobExecutionWithStepCount> getFilteredJobExecutionsWithStepCount(String q, int start, int count) {
+	public List<JobExecutionWithStepCount> getFilteredJobExecutionsWithStepCount(String queryString, int start, int count) {
 		if (start <= 0) {
 			return getJdbcTemplate().query(byJobNameWithStepCountPagingQueryProvider.generateFirstPageQuery(count),
-					new JobExecutionStepCountRowMapper(), "%" + q + "%");
+					new JobExecutionStepCountRowMapper(), "%" + queryString + "%");
 		}
 		try {
 			Long startAfterValue = getJdbcTemplate().queryForObject(
 					executionsWithStepCountPagingQueryProvider.generateJumpToItemQuery(start, count), Long.class);
 			return getJdbcTemplate().query(byJobNameWithStepCountPagingQueryProvider.generateRemainingPagesQuery(count),
-					new JobExecutionStepCountRowMapper(), "%" + q + "%", startAfterValue);
+					new JobExecutionStepCountRowMapper(), "%" + queryString + "%", startAfterValue);
 		}
 		catch (IncorrectResultSizeDataAccessException e) {
 			return Collections.emptyList();

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobService.java
@@ -349,4 +349,16 @@ public interface JobService {
 	 */
 	Collection<JobExecution> listJobExecutionsForJob(String jobName, BatchStatus status, int pageOffset, int pageSize)
 			throws NoSuchJobException;
+
+	/**
+	 * List the {@link JobExecutionWithStepCount JobExecutions} in descending order of
+	 * creation (usually close to execution order) without step execution data filtered by job
+	 * names matching query string.
+	 *
+	 * @param q search query string to filter job names
+	 * @param start the index of the first execution to return
+	 * @param count the maximum number of executions
+	 * @return a collection of {@link JobExecutionWithStepCount}
+	 */
+	Collection<JobExecutionWithStepCount> listFilteredJobExecutionsWithStepCount(String q, int start, int count);
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/JobService.java
@@ -355,10 +355,10 @@ public interface JobService {
 	 * creation (usually close to execution order) without step execution data filtered by job
 	 * names matching query string.
 	 *
-	 * @param q search query string to filter job names
+	 * @param queryString search query string to filter job names
 	 * @param start the index of the first execution to return
 	 * @param count the maximum number of executions
 	 * @return a collection of {@link JobExecutionWithStepCount}
 	 */
-	Collection<JobExecutionWithStepCount> listFilteredJobExecutionsWithStepCount(String q, int start, int count);
+	Collection<JobExecutionWithStepCount> listFilteredJobExecutionsWithStepCount(String queryString, int start, int count);
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SearchableJobExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SearchableJobExecutionDao.java
@@ -138,10 +138,10 @@ public interface SearchableJobExecutionDao extends JobExecutionDao {
 	 * Get the {@link JobExecutionWithStepCount JobExecutions} in reverse order of creation
 	 * (so normally of execution) without StepExecution filtered by job name.
 	 *
-	 * @param q search query string to filter job names
+	 * @param queryString search query string to filter job names
 	 * @param start the start index of the instances
 	 * @param count the maximum number of instances to return
 	 * @return the {@link JobExecutionWithStepCount} instances requested
 	 */
-	List<JobExecutionWithStepCount> getFilteredJobExecutionsWithStepCount(String q, int start, int count);
+	List<JobExecutionWithStepCount> getFilteredJobExecutionsWithStepCount(String queryString, int start, int count);
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SearchableJobExecutionDao.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SearchableJobExecutionDao.java
@@ -133,4 +133,15 @@ public interface SearchableJobExecutionDao extends JobExecutionDao {
 	 * this job
 	 */
 	int countJobExecutions(String jobName, BatchStatus status);
+
+	/**
+	 * Get the {@link JobExecutionWithStepCount JobExecutions} in reverse order of creation
+	 * (so normally of execution) without StepExecution filtered by job name.
+	 *
+	 * @param q search query string to filter job names
+	 * @param start the start index of the instances
+	 * @param count the maximum number of instances to return
+	 * @return the {@link JobExecutionWithStepCount} instances requested
+	 */
+	List<JobExecutionWithStepCount> getFilteredJobExecutionsWithStepCount(String q, int start, int count);
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SimpleJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SimpleJobService.java
@@ -448,6 +448,12 @@ public class SimpleJobService implements JobService, DisposableBean {
 		return jobExecutions;
 	}
 
+	@Override
+	public Collection<JobExecutionWithStepCount> listFilteredJobExecutionsWithStepCount(String q,
+			int start, int count) {
+		return jobExecutionDao.getFilteredJobExecutionsWithStepCount(q, start, count);
+	}
+
 	private List<JobExecution> getJobExecutions(String jobName, BatchStatus status, int pageOffset, int pageSize) {
 		if (StringUtils.isEmpty(jobName)) {
 			if (status != null) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SimpleJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/batch/SimpleJobService.java
@@ -449,9 +449,9 @@ public class SimpleJobService implements JobService, DisposableBean {
 	}
 
 	@Override
-	public Collection<JobExecutionWithStepCount> listFilteredJobExecutionsWithStepCount(String q,
+	public Collection<JobExecutionWithStepCount> listFilteredJobExecutionsWithStepCount(String queryString,
 			int start, int count) {
-		return jobExecutionDao.getFilteredJobExecutionsWithStepCount(q, start, count);
+		return jobExecutionDao.getFilteredJobExecutionsWithStepCount(queryString, start, count);
 	}
 
 	private List<JobExecution> getJobExecutions(String jobName, BatchStatus status, int pageOffset, int pageSize) {

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinController.java
@@ -78,6 +78,7 @@ public class JobExecutionThinController {
 	 * Return a page-able list of {@link JobExecutionThinResource} defined jobs that
 	 * do not contain step execution detail.
 	 *
+	 * @param queryString search query string to filter job names
 	 * @param pageable page-able collection of {@code TaskJobExecution}s.
 	 * @param assembler for the {@link TaskJobExecution}s
 	 * @return a list of Task/Job executions(job executions do not contain step executions.
@@ -86,9 +87,10 @@ public class JobExecutionThinController {
 	 */
 	@RequestMapping(value = "", method = RequestMethod.GET, produces = "application/json")
 	@ResponseStatus(HttpStatus.OK)
-	public PagedModel<JobExecutionThinResource> listJobsOnly(@RequestParam(required = false) String q,
+	public PagedModel<JobExecutionThinResource> listJobsOnly(
+			@RequestParam(value = "q", required = false) String queryString,
 			Pageable pageable, PagedResourcesAssembler<TaskJobExecution> assembler) throws NoSuchJobExecutionException {
-		List<TaskJobExecution> jobExecutions = taskJobService.listJobExecutionsWithStepCount(q, pageable);
+		List<TaskJobExecution> jobExecutions = taskJobService.listJobExecutionsWithStepCount(queryString, pageable);
 		Page<TaskJobExecution> page = new PageImpl<>(jobExecutions, pageable, taskJobService.countJobExecutions());
 		return assembler.toModel(page, jobAssembler);
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/JobExecutionThinController.java
@@ -86,9 +86,9 @@ public class JobExecutionThinController {
 	 */
 	@RequestMapping(value = "", method = RequestMethod.GET, produces = "application/json")
 	@ResponseStatus(HttpStatus.OK)
-	public PagedModel<JobExecutionThinResource> listJobsOnly(Pageable pageable,
-			PagedResourcesAssembler<TaskJobExecution> assembler) throws NoSuchJobExecutionException {
-		List<TaskJobExecution> jobExecutions = taskJobService.listJobExecutionsWithStepCount(pageable);
+	public PagedModel<JobExecutionThinResource> listJobsOnly(@RequestParam(required = false) String q,
+			Pageable pageable, PagedResourcesAssembler<TaskJobExecution> assembler) throws NoSuchJobExecutionException {
+		List<TaskJobExecution> jobExecutions = taskJobService.listJobExecutionsWithStepCount(q, pageable);
 		Page<TaskJobExecution> page = new PageImpl<>(jobExecutions, pageable, taskJobService.countJobExecutions());
 		return assembler.toModel(page, jobAssembler);
 	}

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskJobService.java
@@ -156,14 +156,14 @@ public interface TaskJobService {
 	 * and matches the data with a task id but excludes the step executions.
 	 *
 	 *
-	 * @param q
+	 * @param queryString search query string to filter job names
 	 * @param pageable enumerates the data to be returned.
 	 * @return List containing {@link TaskJobExecution}s.
 	 *
 	 * @throws NoSuchJobExecutionException thrown if the job execution specified does not
 	 *     exist.
 	 */
-	List<TaskJobExecution> listJobExecutionsWithStepCount(String q, Pageable pageable) throws NoSuchJobExecutionException;
+	List<TaskJobExecution> listJobExecutionsWithStepCount(String queryString, Pageable pageable) throws NoSuchJobExecutionException;
 
 	/**
 	 * Retrieves Pageable list of {@link JobExecution} from the JobRepository with a specific

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/TaskJobService.java
@@ -155,13 +155,15 @@ public interface TaskJobService {
 	 * Retrieves Pageable list of {@link JobExecutionWithStepCount}s from the JobRepository
 	 * and matches the data with a task id but excludes the step executions.
 	 *
+	 *
+	 * @param q
 	 * @param pageable enumerates the data to be returned.
 	 * @return List containing {@link TaskJobExecution}s.
 	 *
 	 * @throws NoSuchJobExecutionException thrown if the job execution specified does not
 	 *     exist.
 	 */
-	List<TaskJobExecution> listJobExecutionsWithStepCount(Pageable pageable) throws NoSuchJobExecutionException;
+	List<TaskJobExecution> listJobExecutionsWithStepCount(String q, Pageable pageable) throws NoSuchJobExecutionException;
 
 	/**
 	 * Retrieves Pageable list of {@link JobExecution} from the JobRepository with a specific

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -52,6 +52,7 @@ import org.springframework.cloud.task.repository.TaskExplorer;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Repository that retrieves Tasks and JobExecutions/Instances and the associations
@@ -106,10 +107,18 @@ public class DefaultTaskJobService implements TaskJobService {
 	}
 
 	@Override
-	public List<TaskJobExecution> listJobExecutionsWithStepCount(Pageable pageable) {
+	public List<TaskJobExecution> listJobExecutionsWithStepCount(String q, Pageable pageable) {
 		Assert.notNull(pageable, "pageable must not be null");
-		List<JobExecutionWithStepCount> jobExecutions = new ArrayList<>(
-				jobService.listJobExecutionsWithStepCount(getPageOffset(pageable), pageable.getPageSize()));
+		List<JobExecutionWithStepCount> jobExecutions;
+		if (StringUtils.isEmpty(q)) {
+			jobExecutions = new ArrayList<>(
+					jobService.listJobExecutionsWithStepCount(getPageOffset(pageable), pageable.getPageSize()));
+		}
+		else {
+			jobExecutions = new ArrayList<>(
+					jobService.listFilteredJobExecutionsWithStepCount(q, getPageOffset(pageable),
+							pageable.getPageSize()));
+		}
 		return getTaskJobExecutionsWithStepCountForList(jobExecutions);
 	}
 

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/service/impl/DefaultTaskJobService.java
@@ -107,16 +107,16 @@ public class DefaultTaskJobService implements TaskJobService {
 	}
 
 	@Override
-	public List<TaskJobExecution> listJobExecutionsWithStepCount(String q, Pageable pageable) {
+	public List<TaskJobExecution> listJobExecutionsWithStepCount(String queryString, Pageable pageable) {
 		Assert.notNull(pageable, "pageable must not be null");
 		List<JobExecutionWithStepCount> jobExecutions;
-		if (StringUtils.isEmpty(q)) {
+		if (StringUtils.isEmpty(queryString)) {
 			jobExecutions = new ArrayList<>(
 					jobService.listJobExecutionsWithStepCount(getPageOffset(pageable), pageable.getPageSize()));
 		}
 		else {
 			jobExecutions = new ArrayList<>(
-					jobService.listFilteredJobExecutionsWithStepCount(q, getPageOffset(pageable),
+					jobService.listFilteredJobExecutionsWithStepCount(queryString, getPageOffset(pageable),
 							pageable.getPageSize()));
 		}
 		return getTaskJobExecutionsWithStepCountForList(jobExecutions);


### PR DESCRIPTION
Related to [issue](https://github.com/spring-cloud/spring-cloud-dataflow/issues/3866)
Adding DAO method and updating SImpleJobService as well as Controller to be able to search job executions where job name is like query string coming in via the API Get Request. 