### PR TITLE
Task name length validation

### DIFF
--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
@@ -124,6 +124,7 @@ public class TaskDefinitionController {
 	@RequestMapping(value = "", method = RequestMethod.POST)
 	public TaskDefinitionResource save(@RequestParam("name") String name, @RequestParam("definition") String dsl,
 									   @RequestParam(value = "description", defaultValue = "") String description) {
+		validateTaskName(name);
 		TaskDefinition taskDefinition = new TaskDefinition(name, dsl, description);
 		taskSaveService.saveTaskDefinition(taskDefinition);
 		return new Assembler().toModel(new TaskExecutionAwareTaskDefinition(taskDefinition));
@@ -354,4 +355,10 @@ public class TaskDefinitionController {
 			}
 		}
 	};
+
+	private void validateTaskName(String name) {
+		if (name.length() > 52) {
+			throw new IllegalArgumentException("Length of the task name cannot be greater than 52 characters");
+		}
+	}
 }

--- a/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
+++ b/spring-cloud-dataflow-server-core/src/main/java/org/springframework/cloud/dataflow/server/controller/TaskDefinitionController.java
@@ -357,6 +357,9 @@ public class TaskDefinitionController {
 	};
 
 	private void validateTaskName(String name) {
+		// Kubernetes does not support a pod name with length greater than 63 characters. It also
+		// adds 11 characters to the task name to create a pod, hence we need to ensure that task
+		// name added in SCDF has a length pf less than 52 characters.
 		if (name.length() > 52) {
 			throw new IllegalArgumentException("Length of the task name cannot be greater than 52 characters");
 		}

--- a/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
+++ b/spring-cloud-dataflow-server-core/src/test/java/org/springframework/cloud/dataflow/server/controller/TaskControllerTests.java
@@ -563,4 +563,11 @@ public class TaskControllerTests {
 				.andDo(print()).andExpect(status().isOk());
 
 	}
+
+	@Test
+	public void testSaveErrorTaskNameTooLong() throws Exception {
+		mockMvc.perform(post("/tasks/definitions/")
+				.param("name", "task_with_name_longer_than_fifty_two_characters_error").param("definition", "task")
+				.accept(MediaType.APPLICATION_JSON)).andDo(print()).andExpect(status().is5xxServerError());
+	}
 }


### PR DESCRIPTION
Adding validation to ensure that the length of the task name is not > 52 characters.